### PR TITLE
bugfix/ CORE-238 nested secrets

### DIFF
--- a/src/commands/eval-tpl.js
+++ b/src/commands/eval-tpl.js
@@ -60,6 +60,17 @@ function readLines({ input }) {
   return output;
 }
 
+function stringifyJSON(value) {
+  try {
+    // Stringify value if JSON because env vars cannot be JSON
+    const stringifiedVal = JSON.stringify(value);
+    return stringifiedVal;
+
+} catch (e) {
+    return value;
+}
+}
+
 function buildRules(awsProfile) {
   const profileFlag = awsProfile ? `--profile ${awsProfile}` : '';
   return [
@@ -83,7 +94,8 @@ function buildRules(awsProfile) {
         if (!value) {
           throw new Error('Secret not found');
         }
-        return value;
+
+        return stringifyJSON(value);
       },
     },
     {

--- a/src/commands/eval-tpl.js
+++ b/src/commands/eval-tpl.js
@@ -60,14 +60,9 @@ function readLines({ input }) {
   return output;
 }
 
-function stringifyJSON(value) {
-  try {
-    // Stringify value if JSON because we cannot write JSON to a file
-    const stringifiedVal = JSON.stringify(value);
-    return stringifiedVal;
-  } catch (e) {
-      return value;
-  }
+function transformResponse(value) {
+  // Stringify value if JSON because we cannot write JSON to a file
+  return typeof value === 'object' && value !== null ? JSON.stringify(value) : value;
 }
 
 function buildRules(awsProfile) {
@@ -80,7 +75,7 @@ function buildRules(awsProfile) {
         if (!value) {
           throw new Error(`Env var ${variable} not found`);
         }
-        return value;
+        return transformResponse(value);
       },
     },
     {
@@ -93,7 +88,7 @@ function buildRules(awsProfile) {
         if (!value) {
           throw new Error('Secret not found');
         }
-        return stringifyJSON(value);
+        return transformResponse(value);
       },
     },
     {
@@ -105,7 +100,7 @@ function buildRules(awsProfile) {
         if (!value) {
           throw new Error('SSM Parameter not found');
         }
-        return stringifyJSON(value);
+        return transformResponse(value);
       },
     },
   ];

--- a/src/commands/eval-tpl.js
+++ b/src/commands/eval-tpl.js
@@ -62,13 +62,12 @@ function readLines({ input }) {
 
 function stringifyJSON(value) {
   try {
-    // Stringify value if JSON because env vars cannot be JSON
+    // Stringify value if JSON because we cannot write JSON to a file
     const stringifiedVal = JSON.stringify(value);
     return stringifiedVal;
-
-} catch (e) {
-    return value;
-}
+  } catch (e) {
+      return value;
+  }
 }
 
 function buildRules(awsProfile) {
@@ -94,7 +93,6 @@ function buildRules(awsProfile) {
         if (!value) {
           throw new Error('Secret not found');
         }
-
         return stringifyJSON(value);
       },
     },
@@ -107,7 +105,7 @@ function buildRules(awsProfile) {
         if (!value) {
           throw new Error('SSM Parameter not found');
         }
-        return value;
+        return stringifyJSON(value);
       },
     },
   ];


### PR DESCRIPTION
If an AWS secret key value is a nested JSON object, the value would not get templated properly in the output file. We need to stringify the response if it is JSON so it gets properly written and then set in the file.

Tested both SSM parameters and AWS Secrets.