### PR TITLE
feature/CORE 428 name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,21 @@ OPTIONS
 
 _See code: [src/commands/select-workspace.js](https://github.com/opensesame/core-build-library/blob/v1.0.0/src/commands/select-workspace.js)_
 <!-- commandsstop -->
+
+## `core-build name-prefix`
+
+Calculates the name prefix. If a name is not provided, use the current git branch. Length defaults to 24 characters.
+```
+USAGE
+  $ core-build name-prefix
+
+OPTIONS
+  -h, --help           show CLI help
+  -l, --length=length  [default: 24] length of the name prefix. If not provided, it will default to 24.
+
+  -n, --name=name      name. If not provided, the current git branch will be used (minus the part before a /
+                       character)
+```
+
+_See code: [src/commands/select-workspace.js](https://github.com/opensesame/core-build-library/blob/v1.0.0/src/commands/select-workspace.js)_
+<!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ USAGE
 - [`core-build build-secrets`](#core-build-build-secrets)
 - [`core-build select-workspace`](#core-build-select-workspace)
 - [`core-build eval-tpl`](#core-build-eval-tpl)
+- [`core-build name-prefix`](#core-build-name-prefix)
 
 ## `core-build build-secrets`
 
@@ -87,7 +88,7 @@ OPTIONS
 - Each rule will only be evaluated once per line
 - Rules are evaluated in a set order (Env variables -> AWS Secret -> AWS SSM Parameter). This means they are supported within each other.
 
-_See code: [src/commands/select-workspace.js](https://github.com/opensesame/core-build-library/blob/v1.0.0/src/commands/select-workspace.js)_
+_See code: [src/commands/eval-tpl.js](https://github.com/opensesame/core-build-library/blob/v1.0.0/src/commands/eval-tpl.js)_
 <!-- commandsstop -->
 
 ## `core-build name-prefix`
@@ -99,11 +100,11 @@ USAGE
 
 OPTIONS
   -h, --help           show CLI help
-  -l, --length=length  [default: 24] length of the name prefix. If not provided, it will default to 24.
+  -l, --length=length  [default: 24] length of the name prefix
 
   -n, --name=name      name. If not provided, the current git branch will be used (minus the part before a /
                        character)
 ```
 
-_See code: [src/commands/select-workspace.js](https://github.com/opensesame/core-build-library/blob/v1.0.0/src/commands/select-workspace.js)_
+_See code: [src/commands/name-prefix.js](https://github.com/opensesame/core-build-library/blob/v1.0.0/src/commands/name-prefix.js)_
 <!-- commandsstop -->

--- a/src/commands/name-prefix.js
+++ b/src/commands/name-prefix.js
@@ -18,7 +18,7 @@ NamePrefixCommand.description = 'Calculates the name prefix. If a name is not pr
 NamePrefixCommand.flags = {
   help: flags.help({char: 'h'}),
   name: flags.string({char: 'n', description: 'name. If not provided, the current git branch will be used (minus the part before a / character)'}),
-  length: flags.integer({char: 'l', description: 'length of the name prefix. If not provided, it will default to 24.', default: 24})
+  length: flags.integer({char: 'l', description: 'length of the name prefix', default: 24})
 }
 
 module.exports = NamePrefixCommand;

--- a/src/commands/name-prefix.js
+++ b/src/commands/name-prefix.js
@@ -1,0 +1,24 @@
+const util = require('util');
+const currentBranch = require('current-git-branch');
+const exec = util.promisify(require('child_process').exec);
+const {Command, flags} = require('@oclif/command');
+
+class NamePrefixCommand extends Command {
+  async run() {
+    const {flags} = this.parse(NamePrefixCommand);
+    const branch = currentBranch();
+    const name = flags.name || branch.split('/').slice(-1)[0];
+    const namePrefix = name.substring(0, flags.length);
+    return namePrefix;
+  }
+}
+
+NamePrefixCommand.description = 'Calculates the name prefix. If a name is not provided, use the current git branch. Length defaults to 24 characters.'
+
+NamePrefixCommand.flags = {
+  help: flags.help({char: 'h'}),
+  name: flags.string({char: 'n', description: 'name. If not provided, the current git branch will be used (minus the part before a / character)'}),
+  length: flags.integer({char: 'l', description: 'length of the name prefix. If not provided, it will default to 24.', default: 24})
+}
+
+module.exports = NamePrefixCommand;

--- a/src/commands/name-prefix.js
+++ b/src/commands/name-prefix.js
@@ -1,6 +1,4 @@
-const util = require('util');
 const currentBranch = require('current-git-branch');
-const exec = util.promisify(require('child_process').exec);
 const {Command, flags} = require('@oclif/command');
 
 class NamePrefixCommand extends Command {


### PR DESCRIPTION
- Add a `name-prefix` command that will take in a name, or by default a branch, and shorten it to the desired length